### PR TITLE
Guard menu inventory from unintended item moves

### DIFF
--- a/src/main/java/com/chunksmith/piscary/gui/MenuView.java
+++ b/src/main/java/com/chunksmith/piscary/gui/MenuView.java
@@ -95,8 +95,20 @@ public class MenuView {
     public void handle(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player p)) return;
         if (!e.getView().title().equals(Text.mm(titleMini))) return;
+
+        // Cancel clicks in the top inventory by default so players can't
+        // grab or place items in empty slots. Components may still re-enable
+        // interaction for their own slots if needed.
+        boolean top = e.getRawSlot() < e.getView().getTopInventory().getSize();
+        if (top) e.setCancelled(true);
+
         for (Component c : components) c.click(e);
-        for (Component c : components) c.render(e.getView().getTopInventory(), p);
+
+        // Re-render the menu after handling the click if the click was in the
+        // menu itself. This keeps component visuals in sync after actions.
+        if (top) {
+            for (Component c : components) c.render(e.getView().getTopInventory(), p);
+        }
     }
 
     public List<Component> components() { return components; }


### PR DESCRIPTION
## Summary
- Prevent players from moving items in GUI menus by cancelling clicks in the top inventory unless a component handles them
- Refresh menu visuals only when the click occurs inside the menu

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c5d1b011f88321bed06d72839633b3